### PR TITLE
feat: allow passing array as the first argument

### DIFF
--- a/modern_hooks/queue/mod.nut
+++ b/modern_hooks/queue/mod.nut
@@ -98,6 +98,13 @@
 
 	function require( ... )
 	{
+		if (typeof vargv[0] == "array")
+		{
+			if (vargv.len() > 1)
+				::Hooks.errorAndThrow("cannot pass more than one argument if the first argument is an array");
+			vargv = vargv[0];
+		}
+
 		foreach (modInfo in vargv)
 		{
 			local parsed = this.__parseCompatibilityModInfo(modInfo);
@@ -112,6 +119,13 @@
 
 	function conflictWith( ... )
 	{
+		if (typeof vargv[0] == "array")
+		{
+			if (vargv.len() > 1)
+				::Hooks.errorAndThrow("cannot pass more than one argument if the first argument is an array");
+			vargv = vargv[0];
+		}
+
 		foreach (modInfo in vargv)
 		{
 			local parsed = this.__parseCompatibilityModInfo(modInfo);
@@ -131,8 +145,9 @@
 			bucket = vargv.pop();
 		if (typeof vargv[vargv.len()-1] != "function")
 			::Hooks.errorAndThrow(format("Mod %s (%s) did not pass a function as the last parameter for queue", this.getID(), this.getName()));
+		local queueOrderInfo = typeof vargv[0] == "array" ? vargv[0] : vargv;
 		local func = vargv.pop();
-		this.QueuedFunctions.push(::Hooks.QueuedFunction(this, func, vargv, bucket));
+		this.QueuedFunctions.push(::Hooks.QueuedFunction(this, func, queueOrderInfo, bucket));
 	}
 
 	function hook( _src, _func )


### PR DESCRIPTION
This allows a much more convenient method of passing dependency information without having to resort to manipulation of an array of vars and using acall.

Compare current shenanigans:
- Requires passing `::Hooks` as environment variable.
- Requires manipulating the array every time for every next queue function.
- Requires adding the bucket to the last index in the array.
- Looks extremely ugly that I push the function, and the bucket first to an array, and then call the queue function with `acall`.
- This entire setup seems unnecessarily forced and obtuse for no gain.
![](https://cdn.discordapp.com/attachments/1120066025166209084/1156779042196955236/image.png)

New straightforward method:
- I took this screenshot a before implementing the array for `require`. With the implementation in the PR you won't need to use `acall` on `require` either.
- Code reads in a sensible way now, and functions and variables are where they should be.
- The old method of vargv still is available for simpler mods with less elaborate requirements / dependencies.
![](https://cdn.discordapp.com/attachments/1120066025166209084/1156778983845806100/image.png)