### PR TITLE
fix: remove early return in run queue due to mod compatibility errors

### DIFF
--- a/modern_hooks/private_globals.nut
+++ b/modern_hooks/private_globals.nut
@@ -117,8 +117,7 @@
 
 ::Hooks.__runQueue <- function()
 {
-	if (!this.__validateModCompatibility())
-		return;
+	this.__validateModCompatibility();
 
 	local buckets = {}; // I hate how I've had to do these buckets without MSU enums
 	foreach (mod in this.getMods())


### PR DESCRIPTION
Otherwise the game gets stuck on a black screen during startup and the error popup doesn't show.