### PR TITLE
feat: allow hooks to return a table with the function declared inside

### DIFF
--- a/modern_hooks/q_object.nut
+++ b/modern_hooks/q_object.nut
@@ -44,6 +44,15 @@
 
 	function newSlot( _q, _key, _value )
 	{
+		// Allow wrapping the function in a table so it can be declared with a name that's preserved during hooks
+		if (typeof _value == "table")
+		{
+			if (_key in _value)
+				_value = _value[_key];
+			else
+				::Hooks.errorAndThrow(format("Mod %s (%s) is trying to add key \'%s\' to %s by wrapping it inside a table. But the table is missing that key.", _q.__Mod.getID(), _q.__Mod.getName(), _key, this.buildTargetString(_q)));
+		}
+
 		if (typeof _value != "function")
 			::Hooks.errorAndThrow(format("Mod %s (%s) is trying to add key \'%s\' to %s. The key's value must be a function. Fields must instead be added to the class's \'m\' table.", _q.__Mod.getID(), _q.__Mod.getName(), _key, this.buildTargetString(_q)));
 		local p = _q.__Prototype;
@@ -239,6 +248,10 @@
 				newFunction = _value();
 			else
 				newFunction = _value(oldFunction);
+
+			// Allow wrapping the function in a table so it can be declared with a name that's preserved during hooks
+			if (typeof newFunction == "table")
+				newFunction = newFunction[_key];
 		}
 		catch (error)
 		{


### PR DESCRIPTION
In response to [this feedback](https://discord.com/channels/965324395851694140/1341085093111795823) on Discord, this allows preserving function names in the stack info when hooking and overwriting existing functions.

## Testing
Paste this code to run a test:
```squirrel
::Hooks.__Mod.queue(function() {
	::Hooks.__Mod.hook("scripts/items/weapons/knife", function(q) {
		q.getID = @(__original) function()
		{
			::logInfo("Wrapped as function. Name: " + ::getstackinfos(1).func);
			return __original();
		}

		q.getName = @(__original) {
			function getName()
			{
				::logInfo("Wrapped as table. Name: " + ::getstackinfos(1).func);
				return __original();
			}
		}

		q.getIcon = @() function()
		{
			::logInfo("Wrapped as function without __original. Name: " + ::getstackinfos(1).func);
			return this.m.Icon;
		}

		q.getIconLarge = @() {
			function getIconLarge()
			{
				::logInfo("Wrapped as table without __original. Name: " + ::getstackinfos(1).func);
				return this.m.IconLarge;
			}
		}

		q.foo <- function()
		{
			::logInfo("New function as function. Name: " + ::getstackinfos(1).func);
		}

		q.bar <- {
			function bar()
			{
				::logInfo("New function as table. Name: " + ::getstackinfos(1).func);
			}
		}
	});
});

::Hooks.__Mod.queue(function() {
	local knife = ::new("scripts/items/weapons/knife");
	knife.getID();
	knife.getName();
	knife.getIcon();
	knife.getIconLarge();
	knife.foo();
	knife.bar();
}, ::Hooks.QueueBucket.AfterHooks)
```

Output:
```
04:40:30SQ
Wrapped as function. Name: unknown
04:40:30SQ
Wrapped as table. Name: getName
04:40:30SQ
Wrapped as function without __original. Name: unknown
04:40:30SQ
Wrapped as table without __original. Name: getIconLarge
04:40:30SQ
New function as function. Name: unknown
04:40:30SQ
New function as table. Name: bar
```