### PR TITLE
feat: add error for mods requiring old mod hooks when it is not present

### DIFF
--- a/scripts/!mods_preload/!!zz_modern_hooks_patch_mod_hooks.nut
+++ b/scripts/!mods_preload/!!zz_modern_hooks_patch_mod_hooks.nut
@@ -1,5 +1,12 @@
 if (!("mods_hookExactClass" in this.getroottable()))
+{
+	::mods_registerMod <- function( codeName, version, friendlyName = null, extra = null )
+	{
+		friendlyName = friendlyName == null ? "" : " (" + friendlyName + ")";
+		::Hooks.errorAndQuit(format("Mod %s%s requires the original mod_hooks which is different from Modern Hooks.", codeName, friendlyName));
+	}
 	return;
+}
 ::Hooks.inform("=================Patching Modding Script Hooks=================")
 ::mods_hookExactClass = function( name, func )
 {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b577e7ca-5490-4307-aa50-4078a6fe5109)
