### PR TITLE
Fix parameter validation

### DIFF
--- a/modern_hooks/q_object.nut
+++ b/modern_hooks/q_object.nut
@@ -140,16 +140,16 @@
 		}
 		else if (oldParams.len() != newParams.len())
 		{
-			local oldRequiredParams = oldParams.len() - _oldInfos.defparams.len();
-			local newRequiredParams = newParams.len() - _newInfos.defparams.len();
-			if (oldRequiredParams > newRequiredParams)
+			local oldRequiredParamsNum = oldParams.len() - _oldInfos.defparams.len();
+			local newRequiredParamsNum = newParams.len() - _newInfos.defparams.len();
+			if (oldRequiredParamsNum > newRequiredParamsNum)
 			{
-				::Hooks.error(format("Mod %s (%s) is wrapping function %s in bb class %s with fewer required parameters (used to be %i, wrapper returned function with %i", _q.__Mod.getID(), _q.__Mod.getName(), _key, this.buildTargetString(_q), oldRequiredParams.len()-1, newRequiredParams.len()-1));
+				::Hooks.error(format("Mod %s (%s) is wrapping function %s in bb class %s with fewer required parameters (used to be %i, wrapper returned function with %i)", _q.__Mod.getID(), _q.__Mod.getName(), _key, this.buildTargetString(_q), oldRequiredParamsNum-1, newRequiredParamsNum-1));
 			}
 			// required params number is the same but def params are fewer than before
 			else if (newParams.len() < oldParams.len())
 			{
-				::Hooks.error(format("Mod %s (%s) is wrapping function %s in bb class %s with fewer total parameters (used to be %i, wrapper returned function with %i", _q.__Mod.getID(), _q.__Mod.getName(), _key, this.buildTargetString(_q), oldParams.len()-1, newParams.len()-1));
+				::Hooks.error(format("Mod %s (%s) is wrapping function %s in bb class %s with fewer total parameters (used to be %i, wrapper returned function with %i)", _q.__Mod.getID(), _q.__Mod.getName(), _key, this.buildTargetString(_q), oldParams.len()-1, newParams.len()-1));
 			}
 			// required params number is the same but def params are more than before
 			else if (newParams.len() > oldParams.len())


### PR DESCRIPTION
- Fix an error that crept in in the previous PR #19.

Improve parameter validation:
- fix: not erroring for more new required params if total params are same
- fix: improve vargv validation to more granularly handle all possible cases

- oldHasVargv, newHasVargv, more params -> print warning
```squirrel
function old( _a, _b, ... )
function new( _a, _b, _c, ... )
// This could be due to a safe wrapper so we print warning
```

- oldHasVargv, newHasVargv, fewer parms -> print warning
```squirrel
function old( _a, _b, ... )
function new( _a, ... )
// This could be due to a safe wrapper so we print warning
```

- oldHasVargv, newDoesn't, more params -> print warning
```squirrel
function old( _a, _b, ... )
function new( _a, _b, _c )
// This could be due to a safe wrapper, so we print warning
```

- oldHasVargv, newDoesn't, fewer params -> error
```squirrel
function old( _a, _b, ... )
function new( _a )
// Error because this breaks existing calls to old
```

- oldDoesn't, newHasVargv, more **required** params -> error
```squirrel
function old( _a, _b )
function new( _a, _b, _c ... )
// Error because it breaks existing calls to old

// Another example:
function old( _a, _b = null )
function new( _a, _b, ... )
// Error because existing calls to old with 1 param are broken
```

- oldDoesn't, newHasVargv, fewer params -> logInfo, probably fine
```squirrel
function old( _a, _b )
function new( _a, ... )
// This is probably fine so we just print info
```