### PR TITLE
feat: add history tracking for hooks on specific keys in classes and m 

### DIFF
--- a/modern_hooks/private_globals.nut
+++ b/modern_hooks/private_globals.nut
@@ -91,6 +91,7 @@
 ::Hooks.__executeQueuedFunctions <- function( _queuedFunctions )
 {
 	local root = getroottable();
+	::Hooks.__CurrentBucket = _queuedFunctions[0].Bucket;
 	foreach (queuedFunction in _queuedFunctions)
 	{
 		local mod = queuedFunction.getMod();
@@ -323,7 +324,8 @@
 	this.__initClass(_src);
 	this.BBClass[_src].RawHooks.push({
 		Mod = _mod,
-		hook = _func
+		hook = _func,
+		Bucket = ::Hooks.__CurrentBucket
 	});
 }
 
@@ -340,7 +342,8 @@
 	// useful for debugging
 	this.BBClass[_src].TreeHooks.push({
 		Mod = _mod,
-		hook = _func
+		hook = _func,
+		Bucket = ::Hooks.__CurrentBucket
 	});
 	// actually used by the queue logic
 	this.TreeHooks.push({
@@ -348,6 +351,7 @@
 		Mod = _mod,
 		hook = _func,
 		Src = _src,
+		Bucket = ::Hooks.__CurrentBucket
 	});
 }
 
@@ -366,6 +370,7 @@
 	{
 		try
 		{
+			::Hooks.__CurrentBucket = hookInfo.Bucket;
 			hookInfo.hook.call(root, p);
 		}
 		catch (error)
@@ -427,6 +432,7 @@
 		{
 			try
 			{
+				::Hooks.__CurrentBucket = hookInfo.Bucket;
 				hookInfo.hook.call(root, p);
 			}
 			catch (error)

--- a/modern_hooks/private_globals.nut
+++ b/modern_hooks/private_globals.nut
@@ -298,6 +298,7 @@
 			TreeHooks = [],
 			RawHooks = [],
 			NativeHooks = [],
+			History = {},
 			// MetaHooks = [] to do later
 			Descendants = [],
 			Prototype = null,

--- a/modern_hooks/q_object.nut
+++ b/modern_hooks/q_object.nut
@@ -292,10 +292,12 @@
 
 		_q.__Prototype[_key] <- newFunction;
 
-		if (!(_key in ::Hooks.BBClass[_q.__Src].History))
-			::Hooks.BBClass[_q.__Src].History[_key] <- [];
+		local src = _q instanceof ::Hooks.__Q.QTree ? _q.__Target : _q.__Src;
+
+		if (!(_key in ::Hooks.BBClass[src].History))
+			::Hooks.BBClass[src].History[_key] <- [];
 		local hooksSrcInfos = ::getstackinfos(2);
-		::Hooks.BBClass[_q.__Src].History[_key].push(
+		::Hooks.BBClass[src].History[_key].push(
 			{Mod = _q.__Mod, Bucket = ::Hooks.__CurrentBucket, Wrapper = _value, Old = oldFunction, New = _q.__Prototype[_key], Src = hooksSrcInfos.src + ": " + hooksSrcInfos.line}
 		);
 	}
@@ -321,12 +323,14 @@
 		local oldValue = p.m[_key];
 		p.m[_key] = _value;
 
-		if (!("m" in ::Hooks.BBClass[_q.__Src].History))
-			::Hooks.BBClass[_q.__Src].History.m <- {};
-		if (!(_key in ::Hooks.BBClass[_q.__Src].History.m))
-			::Hooks.BBClass[_q.__Src].History.m[_key] <- [];
+		local src = _q instanceof ::Hooks.__Q.QTree ? _q.__Target : _q.__Src;
+
+		if (!("m" in ::Hooks.BBClass[src].History))
+			::Hooks.BBClass[src].History.m <- {};
+		if (!(_key in ::Hooks.BBClass[src].History.m))
+			::Hooks.BBClass[src].History.m[_key] <- [];
 		local hooksSrcInfos = ::getstackinfos(2);
-		::Hooks.BBClass[_q.__Src].History.m[_key].push(
+		::Hooks.BBClass[src].History.m[_key].push(
 			{Mod = _q.__Mod, Old = oldValue, New = p.m[_key], Src = hooksSrcInfos.src + ": " + hooksSrcInfos.line}
 		);
 	}

--- a/modern_hooks/q_object.nut
+++ b/modern_hooks/q_object.nut
@@ -291,6 +291,13 @@
 		this.validateParameters(_q, _key, oldInfos, newFunction.getinfos());
 
 		_q.__Prototype[_key] <- newFunction;
+
+		if (!(_key in ::Hooks.BBClass[_q.__Src].History))
+			::Hooks.BBClass[_q.__Src].History[_key] <- [];
+		local hooksSrcInfos = ::getstackinfos(2);
+		::Hooks.BBClass[_q.__Src].History[_key].push(
+			{Mod = _q.__Mod, Wrapper = _value, Old = oldFunction, New = _q.__Prototype[_key], Src = hooksSrcInfos.src + ": " + hooksSrcInfos.line}
+		);
 	}
 
 	function set( _q, _key, _value )
@@ -311,7 +318,17 @@
 		local p = this.findInAncestorsM(_q.__Prototype, _key);
 		if (p == null)
 			::Hooks.errorAndThrow(format("Mod %s (%s) tried to set field %s in bb class %s, but the field doesn't exist in the class or any of its ancestors", _q.__Mod.getID(), _q.__Mod.getName(), _key, this.buildTargetString(_q)));
+		local oldValue = p.m[_key];
 		p.m[_key] = _value;
+
+		if (!("m" in ::Hooks.BBClass[_q.__Src].History))
+			::Hooks.BBClass[_q.__Src].History.m <- {};
+		if (!(_key in ::Hooks.BBClass[_q.__Src].History.m))
+			::Hooks.BBClass[_q.__Src].History.m[_key] <- [];
+		local hooksSrcInfos = ::getstackinfos(2);
+		::Hooks.BBClass[_q.__Src].History.m[_key].push(
+			{Mod = _q.__Mod, Old = oldValue, New = p.m[_key], Src = hooksSrcInfos.src + ": " + hooksSrcInfos.line}
+		);
 	}
 
 	function get( _q, _key )
@@ -387,6 +404,24 @@
 			return _key in this.__Prototype;
 		return ::Hooks.__Q.findInAncestors(this.__Prototype, _key) != null;
 	}
+
+	function MH_getHistory( _key )
+	{
+		return _key in ::Hooks.BBClass[this.__Src].History ? ::Hooks.BBClass[this.__Src].History[_key] : [];
+	}
+
+	function MH_revert( _key, _value = "MH_revert" )
+	{
+		if (!(_key in ::Hooks.BBClass[this.__Src].History))
+			return;
+
+		if (_value == "MH_revert")
+		{
+			_value = this.MH_getHistory(_key)[0].Old;
+		}
+
+		this[_key] = @() _value;
+	}
 }
 
 ::Hooks.__Q.QTree <- class extends ::Hooks.__Q.Q {
@@ -437,5 +472,26 @@
 		if (_checkAncestors == false)
 			return _key in this.Q.__Prototype.m;
 		return ::Hooks.__Q.findInAncestorsM(this.Q.__Prototype, _key) != null;
+	}
+
+	function MH_getHistory( _key )
+	{
+		if (!("m" in ::Hooks.BBClass[this.Q.__Src].History))
+			return [];
+
+		return _key in ::Hooks.BBClass[this.Q.__Src].History.m ? ::Hooks.BBClass[this.Q.__Src].History.m[_key] : [];
+	}
+
+	function MH_revert( _key, _value = "MH_revert" )
+	{
+		if (!("m" in ::Hooks.BBClass[this.Q.__Src].History) || !(_key in ::Hooks.BBClass[this.Q.__Src].History.m))
+			return;
+
+		if (_value == "MH_revert")
+		{
+			_value = this.MH_getHistory(_key)[0].Old;
+		}
+
+		this[_key] = _value;
 	}
 }

--- a/modern_hooks/q_object.nut
+++ b/modern_hooks/q_object.nut
@@ -296,7 +296,7 @@
 			::Hooks.BBClass[_q.__Src].History[_key] <- [];
 		local hooksSrcInfos = ::getstackinfos(2);
 		::Hooks.BBClass[_q.__Src].History[_key].push(
-			{Mod = _q.__Mod, Wrapper = _value, Old = oldFunction, New = _q.__Prototype[_key], Src = hooksSrcInfos.src + ": " + hooksSrcInfos.line}
+			{Mod = _q.__Mod, Bucket = ::Hooks.__CurrentBucket, Wrapper = _value, Old = oldFunction, New = _q.__Prototype[_key], Src = hooksSrcInfos.src + ": " + hooksSrcInfos.line}
 		);
 	}
 

--- a/modern_hooks/q_object.nut
+++ b/modern_hooks/q_object.nut
@@ -426,6 +426,26 @@
 
 		this[_key] = @() _value;
 	}
+
+	function MH_snipe( _key, _stateIdx )
+	{
+		local history = this.MH_getHistory(_key);
+		local oldFunction = history[_stateIdx].Old;
+		local newFunction = oldFunction;
+		for (local i = _stateIdx + 1; i < history.len(); i++)
+		{
+			local wrapper = history[i].Wrapper;
+			if (wrapper.getinfos().parameters.len() == 1)
+			{
+				newFunction = wrapper();
+			}
+			else
+			{
+				newFunction = wrapper(newFunction);
+			}
+		}
+		this[_key] = @() newFunction;
+	}
 }
 
 ::Hooks.__Q.QTree <- class extends ::Hooks.__Q.Q {

--- a/scripts/!mods_preload/mod_modern_hooks.nut
+++ b/scripts/!mods_preload/mod_modern_hooks.nut
@@ -41,4 +41,31 @@ foreach (key, value in ::Const.DLC)
 	{
 		::logError("Something went wrong when trying to use MSU's update checker in modern hooks: " + error);
 	}
+
+
+	::Hooks.__Mod.hook("scripts/items/weapons/knife", function(q) {
+		q.m.NewField <- 5;
+
+		q.m.NewField = 6;
+
+		q.getID = @(__original) function()
+		{
+			::logInfo("first hook");
+			return __original();
+		}
+
+		q.getID = @(__original) function()
+		{
+			::logInfo("second hook")
+			return __original();
+		}
+
+		q.MH_snipe("getID", 0);
+	});
 });
+
+::Hooks.__Mod.queue(function() {
+	local knife = ::new("scripts/items/weapons/knife");
+	::logInfo(knife.getID());
+	::logInfo(knife.m.NewField);
+}, ::Hooks.QueueBucket.AfterHooks);

--- a/scripts/config/modern_hooks.nut
+++ b/scripts/config/modern_hooks.nut
@@ -34,6 +34,7 @@
 	RootState = null,
 	MainMenuState = null,
 	DebugMode = false,
+	__CurrentBucket = 0,
 	__SemVerRegex = regexp("^((?:(?:0|[1-9]\\d*)\\.){2}(?:0|[1-9]\\d*))(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"),
 	__VersionOperatorRegex = regexp("^((?:!|=|<|>)?=?)"),
 	__OverloadedFuncNameRegex = regexp("^__sqrat_ol_ \\w+_(\\d+)$"),

--- a/scripts/~~modern_hooks.nut
+++ b/scripts/~~modern_hooks.nut
@@ -2,4 +2,20 @@
 ::Hooks.__finalizeHooks();
 ::Hooks.__runAfterHooksQueue();
 ::Hooks.inform("=================Finalized Hooks=================");
+foreach (src, c in ::Hooks.BBClass)
+{
+	foreach (k, v in c.History)
+	{
+		// ::logInfo(src + "." + k);
+		// foreach (v1 in v)
+		// {
+		// 	foreach (k2, v2 in v1)
+		// 	{
+		// 		::logInfo(k2 + ":" + v2);
+		// 	}
+		// }
+		::logInfo(src + "." + k);
+		::MSU.Log.printData(v, 2, false, 10);
+	}
+}
 //::Hooks.clear()


### PR DESCRIPTION
Each hook on a key in a class or its m table is now tracked. Mods can access this history and revert the state of that key back to a desired value.

All the operations below can be done on the `m` field as well, except `MH_snipe` which is only for functions in the class.

Consider the following scenario:
```squirrel
// Mod A
mod_A.hook("scripts/items/weapons/knife", function(q) {
	q.getID = @(__original) function()
	{
		::logInfo("Mod A's hook worked");
		return __original();
	}
});

// Mod B
mod_B.hook("scripts/items/weapons/knife", function(q) {
	q.getID = @(__original) function()
	{
		::logInfo("Mod B's hook worked");
		return __original();
	}
});
```

Now look at various outcomes:
```squirrel
knife.getID();
// output:
"Mod B's hook worked"
"Mod A's hook worked"
"weapon.knife" // the vanilla output
```

```squirrel
// Mod C
// Reverts getID back to its original declaration (the vanilla one in this case);
mod_C.hook("scripts/items/weapons/knife", function(q) {
	q.MH_revert("getID");
});

knife.getID()
// output:
"weapon.knife"
```

```squirrel
// Mod C
// Reverts getID back to how Mod_A hooked it
mod_C.hook("scripts/items/weapons/knife", function(q) {
	foreach (state in q.MH_getHistory("getID"))
	{
		// Many other checks are possible here e.g. Bucket, and Src of the hook	
		if (state.Mod.getID() == "mod_A")
		{
			q.MH_revert("getID", state.New);
			break;
		}
	}
});

knife.getID();
// output:
"Mod A's hook worked"
"weapon.knife"
```

```squirrel
// Mod C
// Removes Mod_A's hook from the hook stack. This means that the __original
// that is passed to the next hook will be the one from before Mod_A which in this
// case is the vanilla one.
mod_C.hook("scripts/items/weapons/knife", function(q) {
	foreach (i, state in q.MH_getHistory("getID"))
	{
		// Many other checks are possible here e.g. Bucket, and Src of the hook
		if (state.Mod.getID() == "mod_A")
		{
			q.MH_snipe("getID", i);
			break;
		}
	}
});

knife.getID();
// output:
"Mod B's hook worked"
"weapon.knife"
```